### PR TITLE
Correct bad reference to @id_token

### DIFF
--- a/lib/omniauth/strategies/xero_oauth2.rb
+++ b/lib/omniauth/strategies/xero_oauth2.rb
@@ -52,7 +52,7 @@ module OmniAuth
             'email' => '',
           }
         else
-          decoded_info ||= JWT.decode @id_token, nil, false
+          decoded_info ||= JWT.decode id_token, nil, false
           @raw_info ||= decoded_info[0]
         end
       end


### PR DESCRIPTION
Fix for https://github.com/XeroAPI/xero-oauth2-omniauth-strategy/issues/3  `JWT::DecodeError`