### PR TITLE
Allow connections url to be passed in as a parameter

### DIFF
--- a/lib/omniauth/strategies/xero_oauth2.rb
+++ b/lib/omniauth/strategies/xero_oauth2.rb
@@ -12,6 +12,7 @@ module OmniAuth
           site: 'https://api.xero.com/api.xro/2.0',
           authorize_url: 'https://login.xero.com/identity/connect/authorize',
           token_url: 'https://identity.xero.com/connect/token',
+          connections_url: 'https://api.xero.com/connections',
         },
       )
 
@@ -58,7 +59,10 @@ module OmniAuth
       end
 
       def xero_tenants
-        @xero_tenants ||= JSON.parse(access_token.get("https://api.xero.com/connections", {'Authorization'=>('Bearer ' + access_token.token),'Accept'=>'application/json'}).body)
+        clientOptions = options[:client_options]
+        connectionsUrl = clientOptions[:connections_url]
+        response = access_token.get(connectionsUrl, {'Authorization'=>('Bearer ' + access_token.token),'Accept'=>'application/json'}).body
+        @xero_tenants ||= JSON.parse(response)
       end
     end
   end


### PR DESCRIPTION
The rest of the URLs can be passed in as parameters (for mocking, stubbing etc) but this one was missed off