### PR TITLE
Use version from the actual version.rb file

### DIFF
--- a/lib/xero-oauth2/version.rb
+++ b/lib/xero-oauth2/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module XeroOauth2
-    VERSION = '1.0.1'
+    VERSION = '1.0.2'
   end
 end

--- a/omniauth-xero-oauth2.gemspec
+++ b/omniauth-xero-oauth2.gemspec
@@ -1,6 +1,8 @@
+require_relative 'lib/xero-oauth2/version'
+
 Gem::Specification.new do |s|
   s.name        = 'omniauth-xero-oauth2'
-  s.version     = '1.0.2'
+  s.version     = OmniAuth::XeroOauth2::VERSION
   s.licenses    = ['MIT']
   s.summary     = 'OAuth2 Omniauth strategy for Xero.'
   s.description = 'OAuth2 Omniauth straetgy for Xero API.'


### PR DESCRIPTION
- Fix up the version.rb file to match the gemspec

Note this is the default when initialising a gem through bundler now.